### PR TITLE
feat: ブログ記事末尾に Google AdSense 広告を追加

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -39,7 +39,7 @@ theme = 'hugo-coder'
   dateFormat = "2006-01-02"
 
   adsensePublisher = "ca-pub-0944887782985208"
-  # adsenseSlot = ""  # AdSense 管理画面で広告ユニットを作成後、スロット ID を設定する
+  adsenseSlot = "9481478198"
 
   commit = "https://github.com/daruyanagi/daruyanagi.github.io/tree/"
 

--- a/hugo.toml
+++ b/hugo.toml
@@ -38,6 +38,9 @@ theme = 'hugo-coder'
 
   dateFormat = "2006-01-02"
 
+  adsensePublisher = "ca-pub-0944887782985208"
+  # adsenseSlot = ""  # AdSense 管理画面で広告ユニットを作成後、スロット ID を設定する
+
   commit = "https://github.com/daruyanagi/daruyanagi.github.io/tree/"
 
   [taxonomies]

--- a/layouts/partials/head/extensions.html
+++ b/layouts/partials/head/extensions.html
@@ -1,0 +1,3 @@
+{{ with .Site.Params.adsensePublisher }}
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client={{ . }}" crossorigin="anonymous"></script>
+{{ end }}

--- a/layouts/partials/posts/adsense.html
+++ b/layouts/partials/posts/adsense.html
@@ -1,11 +1,9 @@
 {{ with .Site.Params.adsenseSlot }}
-<div style="margin: 2rem 0;">
-  <ins class="adsbygoogle"
-       style="display:block"
-       data-ad-client="{{ $.Site.Params.adsensePublisher }}"
-       data-ad-slot="{{ . }}"
-       data-ad-format="auto"
-       data-full-width-responsive="true"></ins>
-  <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
-</div>
+<ins class="adsbygoogle"
+     style="display:block; text-align:center;"
+     data-ad-layout="in-article"
+     data-ad-format="fluid"
+     data-ad-client="{{ $.Site.Params.adsensePublisher }}"
+     data-ad-slot="{{ . }}"></ins>
+<script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
 {{ end }}

--- a/layouts/partials/posts/adsense.html
+++ b/layouts/partials/posts/adsense.html
@@ -1,0 +1,11 @@
+{{ with .Site.Params.adsenseSlot }}
+<div style="margin: 2rem 0;">
+  <ins class="adsbygoogle"
+       style="display:block"
+       data-ad-client="{{ $.Site.Params.adsensePublisher }}"
+       data-ad-slot="{{ . }}"
+       data-ad-format="auto"
+       data-full-width-responsive="true"></ins>
+  <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
+</div>
+{{ end }}

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -31,6 +31,8 @@
         {{ .Content }}
       </div>
 
+      {{ partial "posts/adsense.html" . }}
+
       <footer>
         <div class="post-meta">
           {{ with .GetTerms "authors" }}{{ partial "taxonomy/authors.html" . }}{{ end }}

--- a/static/ads.txt
+++ b/static/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-0944887782985208, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
Closes #28

## 変更内容

- `static/ads.txt` — Google AdSense 認証用ファイルを追加
- `hugo.toml` — `adsensePublisher` / `adsenseSlot` パラメータを追加
- `layouts/partials/head/extensions.html` — `<head>` に AdSense スクリプトを注入
- `layouts/partials/posts/adsense.html` — 記事末尾に in-article 形式の広告ユニットを追加
- `layouts/posts/single.html` — 本文直後に広告 partial を挿入

## 確認事項

- [x] 記事末尾のみに広告が表示されること
- [x] `https://daruyanagi.jp/ads.txt` にアクセスして内容が返ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)