### PR TITLE
feat: GitHub スタイルの Markdown アラート（callout）を実装

### DIFF
--- a/layouts/_markup/render-blockquote-alert.html
+++ b/layouts/_markup/render-blockquote-alert.html
@@ -1,0 +1,21 @@
+{{- $icons := dict
+  "note"      "fa-circle-info"
+  "tip"       "fa-lightbulb"
+  "important" "fa-circle-exclamation"
+  "warning"   "fa-triangle-exclamation"
+  "caution"   "fa-fire"
+-}}
+{{- $labels := dict
+  "note"      "メモ"
+  "tip"       "ヒント"
+  "important" "重要"
+  "warning"   "警告"
+  "caution"   "注意"
+-}}
+<blockquote class="alert alert-{{ .AlertType }}">
+  <p class="alert-title">
+    <i class="fa-solid {{ index $icons .AlertType }}" aria-hidden="true"></i>
+    {{ index $labels .AlertType }}
+  </p>
+  {{ .Text }}
+</blockquote>

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,0 +1,64 @@
+/* GitHub-style Markdown alerts */
+
+.alert {
+  padding: 0.75rem 1rem;
+  margin: 1rem 0;
+  border-left: 4px solid;
+  border-radius: 4px;
+}
+
+.alert > *:last-child {
+  margin-bottom: 0;
+}
+
+.alert-title {
+  font-weight: 600;
+  margin-bottom: 0.5rem !important;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/* NOTE */
+.alert-note {
+  border-color: #1f6feb;
+  background-color: rgba(31, 111, 235, 0.07);
+}
+.alert-note .alert-title { color: #1f6feb; }
+
+/* TIP */
+.alert-tip {
+  border-color: #238636;
+  background-color: rgba(35, 134, 54, 0.07);
+}
+.alert-tip .alert-title { color: #238636; }
+
+/* IMPORTANT */
+.alert-important {
+  border-color: #8957e5;
+  background-color: rgba(137, 87, 229, 0.07);
+}
+.alert-important .alert-title { color: #8957e5; }
+
+/* WARNING */
+.alert-warning {
+  border-color: #d29922;
+  background-color: rgba(210, 153, 34, 0.07);
+}
+.alert-warning .alert-title { color: #d29922; }
+
+/* CAUTION */
+.alert-caution {
+  border-color: #da3633;
+  background-color: rgba(218, 54, 51, 0.07);
+}
+.alert-caution .alert-title { color: #da3633; }
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+  .alert-note    { background-color: rgba(31, 111, 235, 0.1); }
+  .alert-tip     { background-color: rgba(35, 134, 54, 0.1); }
+  .alert-important { background-color: rgba(137, 87, 229, 0.1); }
+  .alert-warning { background-color: rgba(210, 153, 34, 0.1); }
+  .alert-caution { background-color: rgba(218, 54, 51, 0.1); }
+}


### PR DESCRIPTION
## Summary

- `> [!NOTE]` / `> [!TIP]` / `> [!IMPORTANT]` / `> [!WARNING]` / `> [!CAUTION]` を GitHub に近いデザインでレンダリング
- レンダーフック（`layouts/_markup/render-blockquote-alert.html`）で日本語ラベル・Font Awesome アイコンを出力
- `static/css/custom.css` に配色スタイルを追加（ライト・ダークモード両対応）

## Hugo v0.151.2 での注意点

`.Type` は常に `"alert"` を返すため、種別の判定には `.AlertType` を使用しています。

## Test plan

- [ ] `> [!WARNING]` を含む記事（2026/06/11）でレンダリングを目視確認
- [ ] ライトモード・ダークモードで配色を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)