### PR TITLE
小さい画面で GitHub アクティビティグラフがアイコンに重なるのを修正

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -210,12 +210,17 @@ p:has(> img) {
   padding-top: 1rem;
 }
 
+/* ホーム（と 404）の .centered は flex（row）なので、
+   アクティビティグラフを about ブロックの下に並べるため column にする */
+.centered {
+  flex-direction: column;
+}
+
 #github-grasses {
-  position: absolute;
-  bottom: 9rem;
+  display: block;
   width: 75%;
   max-width: 60rem;
-  z-index: 0;
+  margin: 2rem auto 0;
 }
 
 .web-card {


### PR DESCRIPTION
## 変更内容

Fixes #32

イシューの修正案 1（通常フローに戻す）を採用。

- `#github-grasses` の `position: absolute; bottom: 9rem` を削除し、通常フローで about ブロックの直下に表示
- `.centered`（flex・row 方向）の直接の子になるため、`flex-direction: column` を追加して縦に並べる

## 確認済み

- **480x560**（重なりが再現していたサイズ）: 重なり解消、アイコンとグラフの間に 30px の余白
- **1280x900**（デスクトップ）: アイコン直下の中央にグラフが表示され、自然なレイアウト
- **404 ページ**（`.centered` を使うもう一方のページ）: 子要素が 1 つのため column 化の影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)