### PR TITLE
フッターに GitHub Sponsors ボタンを追加

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -223,6 +223,12 @@ p:has(> img) {
   margin: 2rem auto 0;
 }
 
+/* フッターの GitHub Sponsors ボタン */
+.sponsor-button {
+  margin-top: 1rem;
+  line-height: 0;
+}
+
 .web-card {
   border: 1px solid var(--gh-border);
   border-radius: 0.6rem;

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,0 +1,23 @@
+<footer class="footer">
+  <section class="container">
+    ©
+    {{ if (and .Site.Params.since (lt .Site.Params.since now.Year)) }}
+      {{ .Site.Params.since }} -
+    {{ end }}
+    {{ now.Year }}
+    {{ with .Site.Params.author }} {{ . }} {{ end }}
+    ·
+    {{ if (and .Site.Params.license) }}
+      {{ i18n "licensed_under" }} {{ .Site.Params.license | safeHTML }}
+    ·
+    {{ end }}
+    {{ i18n "powered_by" }} <a href="https://gohugo.io/" target="_blank" rel="noopener">Hugo</a> & <a href="https://github.com/luizdepra/hugo-coder/" target="_blank" rel="noopener">Coder</a>.
+    {{ if (and .Site.Params.commit .GitInfo) }}
+      [<a href="{{ .Site.Params.commit }}/{{ .GitInfo.Hash }}" target="_blank" rel="noopener">{{ .GitInfo.AbbreviatedHash }}</a>]
+    {{ end }}
+
+    <div class="sponsor-button">
+      <iframe src="https://github.com/sponsors/daruyanagi/button" title="Sponsor daruyanagi" height="32" width="114" style="border: 0; border-radius: 6px;"></iframe>
+    </div>
+  </section>
+</footer>


### PR DESCRIPTION
## 変更内容

ブログ全ページのフッターに GitHub Sponsors ボタンを追加しました。

- テーマ（hugo-coder、submodule）の `footer.html` をプロジェクト側 `layouts/partials/footer.html` に上書きし、コピーライト／Powered by 行の下に GitHub Sponsors ボタン（iframe）を配置
- `assets/css/custom.css` に `.sponsor-button { margin-top: 1rem; line-height: 0 }` を追加。中央寄せは `.footer` の `text-align: center` を継承

## レビューポイント

- テーマ本体は変更していません（submodule をクリーンに保つため、override で対応）
- フッターは全ページ共通パーティシャルなので、トップ・記事・一覧すべてに表示されます
- ローカルで表示確認済み（iframe 114x32 で正しくレンダリング、コピーライト行の下に中央寄せ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)