### PR TITLE
style: コードブロックの背景を本文と区別

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -20,6 +20,7 @@ body {
   --gh-border: #d0d7de;
   --gh-muted: #59636e;
   --gh-code-bg: rgba(175, 184, 193, 0.2);
+  --gh-pre-bg: #f6f8fa;
   --gh-stripe-bg: rgba(140, 149, 159, 0.1);
   --gh-alert-alpha: 0.07;
 }
@@ -28,6 +29,7 @@ body.colorscheme-dark {
   --gh-border: #444c56;
   --gh-muted: #9198a1;
   --gh-code-bg: rgba(110, 118, 129, 0.4);
+  --gh-pre-bg: #18181b;
   --gh-alert-alpha: 0.1;
 }
 
@@ -36,6 +38,7 @@ body.colorscheme-dark {
     --gh-border: #444c56;
     --gh-muted: #9198a1;
     --gh-code-bg: rgba(110, 118, 129, 0.4);
+    --gh-pre-bg: #18181b;
     --gh-alert-alpha: 0.1;
   }
 }
@@ -124,6 +127,17 @@ body:is(.colorscheme-light, .colorscheme-dark, .colorscheme-auto) pre code {
   border-radius: 0;
   background-color: inherit;
   color: inherit;
+}
+
+/* ===== コードブロック（本文背景と区別） =====
+   theme の pre は背景未指定で本文と同色になり区別しづらいので、
+   一段沈んだ背景＋枠線を与える。左端は 1 文字分ほど余白を足す。
+   chroma（言語指定あり）のインラインスタイルは !important なしなので
+   上書きしない。 */
+body:is(.colorscheme-light, .colorscheme-dark, .colorscheme-auto) pre {
+  background-color: var(--gh-pre-bg);
+  border: 1px solid var(--gh-border);
+  padding-left: 2rem;
 }
 
 /* ===== 引用（GitHub 風: 斜体をやめてグレー文字に） ===== */


### PR DESCRIPTION
## 概要
コードブロックが本文と同色で埋もれて見分けづらかったので、背景・枠線・左余白を付けて区別しやすくします。

## 背景（原因）
- このサイトの code fence は言語指定なしのプレーン ` ``` ` が多く、その場合 chroma（monokai）が効かず `<pre>` は素のまま。
- テーマ（hugo-coder）の `pre` は `background-color` 未指定 → 本文（ページ背景）と同色になる。
- さらに custom.css が `pre code` を透明にしていたため、ブロック全体が本文に埋もれていた。

## 変更点（CSS のみ・[assets/css/custom.css](assets/css/custom.css)）
- `--gh-pre-bg` 変数を追加（light: `#f6f8fa` / dark: `#18181b`）
- `pre` に背景色＋ `1px` の枠線（`var(--gh-border)`）を付与
- 左端に 1 文字分ほどの余白（`padding-left: 2rem`）
- `!important` を使わないため、**言語指定ありの code fence（chroma/monokai）には影響しない**

## 確認
- ローカル Hugo + Playwright で light / dark 両モードを目視確認
  - Light: 本文 `#fafafa` ↔ コードブロック `#f6f8fa` ＋枠線
  - Dark: 本文 `#212121` ↔ コードブロック `#18181b` ＋枠線

🤖 Generated with [Claude Code](https://claude.com/claude-code)